### PR TITLE
Visitor performance

### DIFF
--- a/core/src/main/java/com/github/maracas/visitors/MethodReturnTypeChangedVisitor.java
+++ b/core/src/main/java/com/github/maracas/visitors/MethodReturnTypeChangedVisitor.java
@@ -42,6 +42,16 @@ public class MethodReturnTypeChangedVisitor extends BreakingChangeVisitor {
 	private final CtTypeReference<?> newType;
 
 	/**
+	 * Actual method that has been changed
+	 */
+	private final CtMethod<?> method;
+
+	/**
+	 * Type expected by the new method
+	 */
+	private final CtTypeReference<?> expectedType;
+
+	/**
 	 * Creates a MethodReturnTypeChangedVisitor instance.
 	 *
 	 * @param mRef    the modified method
@@ -51,6 +61,8 @@ public class MethodReturnTypeChangedVisitor extends BreakingChangeVisitor {
 		super(JApiCompatibilityChange.METHOD_RETURN_TYPE_CHANGED);
 		this.mRef = mRef;
 		this.newType = newType;
+		this.method = (CtMethod<?>) mRef.getExecutableDeclaration();
+		this.expectedType = SpoonHelpers.inferExpectedType(method);
 	}
 
 	@Override
@@ -66,12 +78,7 @@ public class MethodReturnTypeChangedVisitor extends BreakingChangeVisitor {
 
 	@Override
 	public <T> void visitCtMethod(CtMethod<T> m) {
-		if (mRef.getExecutableDeclaration() instanceof CtMethod<?> method) {
-			CtTypeReference<?> expectedType = SpoonHelpers.inferExpectedType(method);
-			if (m.isOverriding(method) && !SpoonTypeHelpers.isAssignableFrom(newType, expectedType))
-				brokenUse(m, method, mRef, APIUse.METHOD_OVERRIDE);
-		} else {
-			throw new RuntimeException(String.format("%s should be a method.", mRef.getSimpleName()));
-		}
+		if (m.getSignature().equals(method.getSignature()) && m.isOverriding(method) && !SpoonTypeHelpers.isAssignableFrom(newType, expectedType))
+			brokenUse(m, method, mRef, APIUse.METHOD_OVERRIDE);
 	}
 }


### PR DESCRIPTION
The way our visitors are implemented, every source code element in a client is visited by every single visitor as long as it implements the corresponding visit method.

This means that visit methods should avoid costly computations and, when this isn't possible, try to return as early as possible (for instance using a dummy check that discards 99% of cases and only checks thoroughly the remaining 1%).

After some profiling, it seems that `MethodReturnTypeChangedVisitor` and `SuperTypeRemovedVisitor` are the two worst so I fixed them, but basically, anything that involves override- or subtype- checks costs a lot.

Locally, `maracas-core`'s test suite goes from 13min 24s to 3min 28s with this PR. Hopefully nothing breaks, tests do not complain.

