### PR TITLE
Better REST concurrency

### DIFF
--- a/forges/src/main/java/com/github/maracas/forges/ForgeAnalyzer.java
+++ b/forges/src/main/java/com/github/maracas/forges/ForgeAnalyzer.java
@@ -56,11 +56,13 @@ public class ForgeAnalyzer {
     throws InterruptedException, ExecutionException {
     Objects.requireNonNull(delta);
 
-    if (delta.getBreakingChanges().isEmpty())
+    if (delta.getBreakingChanges().isEmpty()) {
+      clients.forEach(c -> c.getClonePath().toFile().mkdirs());
       return AnalysisResult.noImpact(
         delta,
         clients.stream().map(c -> new SourcesDirectory(c.getClonePath())).toList()
       );
+    }
 
     List<CompletableFuture<DeltaImpact>> clientFutures =
       clients.stream().map(c ->

--- a/rest/src/main/java/com/github/maracas/rest/services/PullRequestService.java
+++ b/rest/src/main/java/com/github/maracas/rest/services/PullRequestService.java
@@ -18,6 +18,7 @@ import com.github.maracas.rest.data.MaracasReport;
 import com.github.maracas.rest.data.PullRequestResponse;
 import japicmp.config.Options;
 import japicmp.util.Optional;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -257,6 +258,7 @@ public class PullRequestService {
 			.resolve(c.repository().owner())
 			.resolve(c.repository().name())
 			.resolve(c.sha())
+			.resolve(RandomStringUtils.randomAlphanumeric(12))
 			.toAbsolutePath();
 	}
 }

--- a/rest/src/main/resources/application-test.properties
+++ b/rest/src/main/resources/application-test.properties
@@ -1,5 +1,5 @@
 maracas.clone-path=./data-test/clones
 maracas.report-path=./data-test/reports
-maracas.threads=-1
+maracas.analysisWorkers=-1
 logging.file.path=./data-test/logs
 spring.main.allow-bean-definition-overriding=true

--- a/rest/src/main/resources/application.properties
+++ b/rest/src/main/resources/application.properties
@@ -6,4 +6,4 @@ logging.level.org.springframework.web.filter.CommonsRequestLoggingFilter=DEBUG
 maracas.breakbot-file=.github/breakbot.yml
 maracas.clone-path=./data/clones
 maracas.report-path=./data/reports
-maracas.threads=-1
+maracas.analysisWorkers=-1


### PR DESCRIPTION
- Avoid file system clashes between concurrent clone operations
- Let the REST controller treat all requests concurrently using the default `ForkJoinPool.commonPool()`
- Share one single instance of `ForgeAnalyzer` for all analysis requests requested through REST; by default, `ForgeAnalyzer` uses the `ForkJoinPool.commonPool()`
- If set with `maracas.analysisWorkers`, create a customized `ThreadPoolExecutor` with the appropriate number of threads to the underlying `ForgeAnalyzer`